### PR TITLE
fix(notifier): Correctly throw UnknownNotificationException

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -23,7 +23,7 @@ class Notifier implements INotifier {
     public function prepare(INotification $notification, string $languageCode): INotification {
         if ($notification->getApp() !== 'journeys') {
             // Not our app
-            return $notification;
+            throw new UnknownNotificationException('app');
         }
         $subject = (string)$notification->getSubject();
         $params = (array)$notification->getSubjectParameters();


### PR DESCRIPTION
- Otherwise the notification manager assumes the notification is rendered. Ref https://github.com/nextcloud/notifications/issues/2615
- Fix https://github.com/thrillfall/journeys/issues/14
